### PR TITLE
map_bitfieldarray: Allow empty arrays

### DIFF
--- a/values.py
+++ b/values.py
@@ -842,6 +842,10 @@ def map_bitfieldarray(typename, iterator, map_fn=lambda x: x, debug=True, non_va
     :return: A BitFieldArray
     """
     structs = list(map(lambda elm: collections.OrderedDict(call_map_varargs(map_fn, elm, non_varargs)), iterator))
+
+    if not structs:
+        return Reference(None)
+
     array = (BitFieldArray(typename, *structs[0].keys())
              .addAll([struct.values() for struct in structs]))
 


### PR DESCRIPTION
* This way if a compression module is simple enough, we won't have to create a stub struct separately.
* If no values appear in the bitfieldarray I just return a nullptr instead. Would this have any bad implications?