### PR TITLE
Feat/struct member overwrite

### DIFF
--- a/stringhelper.py
+++ b/stringhelper.py
@@ -8,7 +8,8 @@ indent = " " * 4
 # ********** packing *********************************************************
 # takes a string and returns it as a null terminated string of bytes char
 def stringToChars(string):
-    bytesString = bytes(string, 'utf-8') + b"\0"
+    bytesString = string if isinstance(string, bytes) else bytes(string, 'utf-8')
+    bytesString += b"\0"
     arrayOfIndividualBytes = []
     for charValue in bytesString:
         arrayOfIndividualBytes.append(bytes([charValue]))

--- a/values.py
+++ b/values.py
@@ -715,6 +715,17 @@ class Struct(Value, namedstruct.constants.AddConstantFunctions):
         self.values.extend([Padding()] * padBytes)
         return self
 
+    def overwrite(self, key, value):
+        index = self.type.members[key]
+        old_type = self.type.types[index]
+        new_value = getValue(dictGet(value, key))
+        # FIXME: This part might not be right, didn't think about it hard enough
+        assert old_type.getAlignment() == new_value.getType().getAlignment()
+        self.type.types[index] = new_value.getType()
+        self.values[index] = new_value
+        return self
+
+
     def pretty(self):
         result = "struct " + self.type.getName() + " {"
         length = max([0] + [len(repr(self.type.getMember(i)[1])) for i in range(len(self.values))])

--- a/values.py
+++ b/values.py
@@ -721,6 +721,7 @@ class Struct(Value, namedstruct.constants.AddConstantFunctions):
         new_value = getValue(dictGet(value, key))
         # FIXME: This part might not be right, didn't think about it hard enough
         assert old_type.getAlignment() == new_value.getType().getAlignment()
+        assert old_type.getWidth() == new_value.getType().getWidth()
         self.type.types[index] = new_value.getType()
         self.values[index] = new_value
         return self

--- a/values.py
+++ b/values.py
@@ -113,7 +113,7 @@ class Int(PrimitiveValue):
     def __init__(self, intValue, unsigned=False, bitWidth=32):
         valueType = namedstruct.n_types.IntType(unsigned, bitWidth)
         valueType.assertValueHasType(intValue)
-        PrimitiveValue.__init__(self, valueType, intValue)
+        PrimitiveValue.__init__(self, valueType, int(intValue))
 
     def getLiteral(self):
         return str(self.getPythonValue())
@@ -851,7 +851,7 @@ class BitFieldArray(Value):
                 if not (0 <= value < 2 ** 31):
                     raise Exception(
                         "bitFieldArray only supports values between 0 (incl) and 2^31 (excl), received " + repr(value))
-                entry.append((False, value))
+                entry.append((False, int(value)))
         self.entries.append(entry)
         return self
 

--- a/values.py
+++ b/values.py
@@ -719,7 +719,7 @@ class Struct(Value, namedstruct.constants.AddConstantFunctions):
         index = self.type.members[key]
         old_type = self.type.types[index]
         new_value = getValue(dictGet(value, key))
-        # FIXME: This part might not be right, didn't think about it hard enough
+        # This check is intended to ensure the new value will not cause any pointers to shift
         assert old_type.getAlignment() == new_value.getType().getAlignment()
         assert old_type.getWidth() == new_value.getType().getWidth()
         self.type.types[index] = new_value.getType()


### PR DESCRIPTION
* Allow overwriting an existing field in a namedstruct Struct, assuming it will fit in the space allocated.
* Remove association to original enum type when added to a namedstruct so that unpickling won't require a copy of the compressor source code.
* Blob needed some changes to corrrectly handle bytes in Python 3 for some reason.