### PR TITLE
eliminate magic constants and other improvements

### DIFF
--- a/namedstruct/bits.h
+++ b/namedstruct/bits.h
@@ -170,10 +170,22 @@ namespace namedstruct {
 
     /** returns the Word at the memory location starting at the given pointer, stored in little endian order. */
     static inline Word getWord(const void* littleEndianData) {
+        static_assert(sizeof(Word) == 4 || sizeof(Word) == 8);
+
+        // manually-unrolled loop so even clang with -O1 can optimize this to a single instruction
         Word result = 0;
-        for (std::size_t i = 0; i < sizeof(Word); ++i) {
-            result |= reinterpret_cast<const uint8_t*>(littleEndianData)[i] << (i * 8);
+        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[0];
+        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[1] << 8;
+        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[2] << 16;
+        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[3] << 24;
+
+        if constexpr (sizeof(Word) == 8) { // future-proofing the code
+            result |= reinterpret_cast<const uint8_t*>(littleEndianData)[4] << 32;
+            result |= reinterpret_cast<const uint8_t*>(littleEndianData)[5] << 40;
+            result |= reinterpret_cast<const uint8_t*>(littleEndianData)[6] << 48;
+            result |= reinterpret_cast<const uint8_t*>(littleEndianData)[7] << 56;
         }
+
         return result;
     }
 

--- a/namedstruct/bits.h
+++ b/namedstruct/bits.h
@@ -192,16 +192,16 @@ namespace namedstruct {
     }
 
     /** calculates the absolute minimum number of bits needed to store an integer Num.
-     *  E.g.: numBits<32>() is 6 since 32 = 0b100000. */
+     *  E.g.: bitSize<32>() is 6 since 32 = 0b100000. */
     template <std::size_t Num>
-    static constexpr std::size_t numBits() {
+    static constexpr std::size_t bitSize() {
         constexpr auto SmallerNum = Num >> 1;
-        return Num == 0 ? 0 : numBits<SmallerNum>() + 1;
+        return Num == 0 ? 0 : bitSize<SmallerNum>() + 1;
     }
 
     /** calculates x / WordWidth using a right shift */
     static inline auto fastDivisionByWordWidth(int x) {
-        return x >> numBits<WordWidth - 1>();
+        return x >> bitSize<WordWidth - 1>();
     }
 
     /** Masks the shift exponent to n bits to mimic IA-32 behaviour. For instance, n = 5 when shifting a 32-bit word.

--- a/namedstruct/bits.h
+++ b/namedstruct/bits.h
@@ -177,16 +177,22 @@ namespace namedstruct {
         return result;
     }
 
+    /** calculates the absolute minimum number of bits needed to store an integer Num. */
     template <std::size_t Num>
     static constexpr std::size_t numbits() {
         constexpr auto SmallerNum = Num >> 1;
         return Num == 0 ? 0 : numbits<SmallerNum>() + 1;
     }
 
+    /** calculates x / WordWidth using a right shift */
     static inline auto fastDivisionByWordWidth(int x) {
         return x >> numbits<WordWidth - 1>();
     }
 
+    /** Masks the shift exponent to n bits to mimic IA-32 behaviour. For instance, n = 5 when shifting a 32-bit word.
+     *  (SAL/SAR/SHL/SHR – Shift, Chapter 4. Instruction Set Reference, IA-32 Intel Architecture Software Developer’s
+     *   Manual)
+     */
     static inline auto masked(int x) {
         return Shift<Word>::masked(x);
     }

--- a/namedstruct/bits.h
+++ b/namedstruct/bits.h
@@ -170,23 +170,25 @@ namespace namedstruct {
 
     /** returns the Word at the memory location starting at the given pointer, stored in little endian order. */
     static inline Word getWord(const void* littleEndianData) {
+        #define GET_BYTE(data, i) static_cast<Word>(reinterpret_cast<const uint8_t*>(data)[i])
         static_assert(sizeof(Word) == 4 || sizeof(Word) == 8);
 
         // manually-unrolled loop so even clang with -O1 can optimize this to a single instruction
         Word result = 0;
-        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[0];
-        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[1] << 8;
-        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[2] << 16;
-        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[3] << 24;
+        result |= GET_BYTE(littleEndianData, 0);
+        result |= GET_BYTE(littleEndianData, 1) << 8;
+        result |= GET_BYTE(littleEndianData, 2) << 16;
+        result |= GET_BYTE(littleEndianData, 3) << 24;
 
         if constexpr (sizeof(Word) == 8) { // future-proofing the code
-            result |= reinterpret_cast<const uint8_t*>(littleEndianData)[4] << 32;
-            result |= reinterpret_cast<const uint8_t*>(littleEndianData)[5] << 40;
-            result |= reinterpret_cast<const uint8_t*>(littleEndianData)[6] << 48;
-            result |= reinterpret_cast<const uint8_t*>(littleEndianData)[7] << 56;
+            result |= GET_BYTE(littleEndianData, 4) << 32;
+            result |= GET_BYTE(littleEndianData, 5) << 40;
+            result |= GET_BYTE(littleEndianData, 6) << 48;
+            result |= GET_BYTE(littleEndianData, 7) << 56;
         }
 
         return result;
+        #undef GET_BYTE
     }
 
     /** calculates the absolute minimum number of bits needed to store an integer Num.

--- a/namedstruct/bits.h
+++ b/namedstruct/bits.h
@@ -192,16 +192,16 @@ namespace namedstruct {
     }
 
     /** calculates the absolute minimum number of bits needed to store an integer Num.
-     *  E.g.: numbits<32>() is 6 since 32 = 0b100000. */
+     *  E.g.: numBits<32>() is 6 since 32 = 0b100000. */
     template <std::size_t Num>
-    static constexpr std::size_t numbits() {
+    static constexpr std::size_t numBits() {
         constexpr auto SmallerNum = Num >> 1;
-        return Num == 0 ? 0 : numbits<SmallerNum>() + 1;
+        return Num == 0 ? 0 : numBits<SmallerNum>() + 1;
     }
 
     /** calculates x / WordWidth using a right shift */
     static inline auto fastDivisionByWordWidth(int x) {
-        return x >> numbits<WordWidth - 1>();
+        return x >> numBits<WordWidth - 1>();
     }
 
     /** Masks the shift exponent to n bits to mimic IA-32 behaviour. For instance, n = 5 when shifting a 32-bit word.

--- a/namedstruct/bits.h
+++ b/namedstruct/bits.h
@@ -231,7 +231,7 @@ namespace namedstruct {
     }
 
     static inline int getBitOffset(const void* pDataOriginal, const void* pDataNow, int currentBitsLeftInWord) {
-        return int((intptr_t(pDataNow)-intptr_t(pDataOriginal))<<3) + (32-currentBitsLeftInWord);
+        return int((intptr_t(pDataNow)-intptr_t(pDataOriginal))<<3) + (WordWidth - currentBitsLeftInWord);
     }
     
     

--- a/namedstruct/bits.h
+++ b/namedstruct/bits.h
@@ -168,16 +168,17 @@ namespace namedstruct {
         return reinterpret_cast<const void*>(reinterpret_cast<const Word*>(pData) + numWords);
     }
 
+    /** returns the Word at the memory location starting at the given pointer, stored in little endian order. */
     static inline Word getWord(const void* littleEndianData) {
-        static_assert(sizeof(Word) == 4);
-        Word result = reinterpret_cast<const uint8_t*>(littleEndianData)[0];
-        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[1] << 8;
-        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[2] << 16;
-        result |= reinterpret_cast<const uint8_t*>(littleEndianData)[3] << 24;
+        Word result = 0;
+        for (std::size_t i = 0; i < sizeof(Word); ++i) {
+            result |= reinterpret_cast<const uint8_t*>(littleEndianData)[i] << (i * 8);
+        }
         return result;
     }
 
-    /** calculates the absolute minimum number of bits needed to store an integer Num. */
+    /** calculates the absolute minimum number of bits needed to store an integer Num.
+     *  E.g.: numbits<32>() is 6 since 32 = 0b100000. */
     template <std::size_t Num>
     static constexpr std::size_t numbits() {
         constexpr auto SmallerNum = Num >> 1;

--- a/namedstruct/bits.h
+++ b/namedstruct/bits.h
@@ -37,28 +37,28 @@ namespace namedstruct {
     /**
      reads numBits bits bitOffset bits away from data and returns it as an uint32.
      numBits has to be <= 31. Will always access the 32-bit memory value that this points to. */
-    static inline Word readBits(const void* pData,int bitOffset,int numBits);
+    static inline Word readBits(const void* pData, int bitOffset, int numBits);
     
     /** Sets up the sequential reading of bit values.
      The currentWord and currentBitsLeftInWord will be assigned by this, and the data
      pointer will be pointed at the current word that is being read. To use the
      "readNext" functions, the pData, currentWord and currentBitsLeft in word have to be
      supplied. This will ensure that words are only loaded as needed. */
-    static inline void startReadBits(const void* &pData,int bitOffset,
+    static inline void startReadBits(const void* &pData, int bitOffset,
                                      Word &currentWord, int &currentBitsLeftInWord);
     
     /** peforms a sequential reading of bit values. numBits has to be <= 31.
      pData, currentWord and currentBitsLeftInWord Have to be initialized by startReadBits */
-    static inline Word readNextBits(const void* &pData,Word &currentWord,
-                                        int &currentBitsLeftInWord,int numBits);
+    static inline Word readNextBits(const void* &pData, Word &currentWord,
+                                        int &currentBitsLeftInWord, int numBits);
     
     /** performs a sequential read of a single bit value
      pData, currentWord and currentBitsLeftInWord Have to be initialized by startReadBits */
-    static inline int readNextBit(const void* &pData,Word &currentWord,int &currentBitsLeftInWord);
+    static inline int readNextBit(const void* &pData, Word &currentWord, int &currentBitsLeftInWord);
     
     /** while performing a sequential read operation, skips ahead by numBits, where numBits >= 0 */
-    static inline void skipNextBits(const void* &pData,Word &currentWord,
-                                    int &currentBitsLeftInWord,int numBits);
+    static inline void skipNextBits(const void* &pData, Word &currentWord,
+                                    int &currentBitsLeftInWord, int numBits);
     
     /** given the data pointer given to startReadBits, the current data pointer, and the
      current bits left in word, returns the bit offset from the original data pointer
@@ -71,20 +71,20 @@ namespace namedstruct {
      pointer will be pointed at the current word that is being read. To use the
      "readPrevious" functions, the pData, currentWord and currentBitsLeft in word have to be
      supplied. This will ensure that words are only loaded as needed. */
-    static inline void startReversedReadBits(const void* &pData,int bitOffset,
+    static inline void startReversedReadBits(const void* &pData, int bitOffset,
                                              Word &currentWord, int &currentBitsLeftInWord);
     
     /** performs a reverse sequential read of a single bit value.
      pData, currentWord and currentBitsLeftInWord Have to be initialized by startReversedReadBits.
      The returned bit is the the one that comes before the current location. */
-    static inline int readPreviousBit(const void* &pData,Word &currentWord,int &currentBitsLeftInWord);
+    static inline int readPreviousBit(const void* &pData, Word &currentWord, int &currentBitsLeftInWord);
     
     /** performs a reverse sequential read of bit values. numBits has to be <= 31.
      pData, currentWord and currentBitsLeftInWord Have to be initialized by startReversedReadBits.
      This will first step backwards by numBits bits, and then return numBits bits starting at
      that location. */
-    static inline Word readPreviousBits(const void* &pData,Word &currentWord,
-                                            int &currentBitsLeftInWord,int numBits);
+    static inline Word readPreviousBits(const void* &pData, Word &currentWord,
+                                            int &currentBitsLeftInWord, int numBits);
     
     /**
      returns the number of bits required to store the given number: 0 -> 0, 255 -> 8, 256 -> 9 */
@@ -201,7 +201,7 @@ namespace namedstruct {
         return getLSB(first | second, numBits);
     }
 
-    static inline void startReadBits(const void* &pData,int bitOffset,
+    static inline void startReadBits(const void* &pData, int bitOffset,
                                      Word &currentWord, int &currentBitsLeftInWord) {
         pData = advance(pData, fastDivisionByWordWidth(bitOffset)); //get pointer to the correct location
         int bitAddress = masked(bitOffset);
@@ -236,7 +236,7 @@ namespace namedstruct {
         return 0;
     }
     
-    static inline int readNextBit(const void* &pData,Word &currentWord,int &currentBitsLeftInWord) {
+    static inline int readNextBit(const void* &pData, Word &currentWord, int &currentBitsLeftInWord) {
         if (__builtin_expect(currentBitsLeftInWord == 0, 0)) {
             pData = advance(pData, 1); //advance pointer
             currentWord = getWord(pData);
@@ -248,8 +248,8 @@ namespace namedstruct {
         return result;
     }
     
-    static inline void skipNextBits(const void* &pData,Word &currentWord,
-                                    int &currentBitsLeftInWord,int numBits){
+    static inline void skipNextBits(const void* &pData, Word &currentWord,
+                                    int &currentBitsLeftInWord, int numBits){
         if (numBits < currentBitsLeftInWord) {
             currentBitsLeftInWord -= numBits;
             currentWord >>= numBits;
@@ -260,11 +260,11 @@ namespace namedstruct {
         /*
          //TODO - dummy implementation, do something better and test it
          for (int i = 0; i < numBits; i++){
-         readNextBit(pData,currentWord,currentBitsLeftInWord);
+         readNextBit(pData, currentWord, currentBitsLeftInWord);
          }*/
     }
 
-    static inline void startReversedReadBits(const void* &pData,int bitOffset,
+    static inline void startReversedReadBits(const void* &pData, int bitOffset,
                                              Word &currentWord,
                                              int &currentBitsLeftInWord) {
         int bitAddress = masked(bitOffset-1) + 1; // get lower bits, but 32->32, 0->32
@@ -275,7 +275,7 @@ namespace namedstruct {
         currentBitsLeftInWord = bitAddress;
     }
     
-    static inline Word readPreviousBits(const void* &pData,Word &currentWord,
+    static inline Word readPreviousBits(const void* &pData, Word &currentWord,
                                             int &currentBitsLeftInWord, int numBits) {
         if (numBits > currentBitsLeftInWord) {
             // data is in current word, and previous
@@ -300,7 +300,7 @@ namespace namedstruct {
         return 0;
     }
     
-    static inline int readPreviousBit(const void* &pData,Word &currentWord,int &currentBitsLeftInWord) {
+    static inline int readPreviousBit(const void* &pData, Word &currentWord, int &currentBitsLeftInWord) {
         if (__builtin_expect(currentBitsLeftInWord == 0, 0)) {
             pData = advance(pData, -1); //step pointer backwards
             currentWord = getWord(pData);

--- a/namedstruct/shiftTests.mm
+++ b/namedstruct/shiftTests.mm
@@ -27,22 +27,23 @@
 
 #pragma mark - tests
 
-- (void)testClamp {
+- (void)testMask {
+    using namedstruct::Shift;
     using namedstruct::NonNegative;
 
     constexpr auto x = NonNegative(std::numeric_limits<uint64_t>::max());
 
-    XCTAssertEqual(x.clamped<std::int8_t>(), 7);
-    XCTAssertEqual(x.clamped<std::uint8_t>(), 7);
+    XCTAssertEqual(Shift<std::int8_t>::masked(x), 7);
+    XCTAssertEqual(Shift<std::uint8_t>::masked(x), 7);
 
-    XCTAssertEqual(x.clamped<std::int16_t>(), 15);
-    XCTAssertEqual(x.clamped<std::uint16_t>(), 15);
+    XCTAssertEqual(Shift<std::int16_t>::masked(x), 15);
+    XCTAssertEqual(Shift<std::uint16_t>::masked(x), 15);
 
-    XCTAssertEqual(x.clamped<std::int32_t>(), 31);
-    XCTAssertEqual(x.clamped<std::uint32_t>(), 31);
+    XCTAssertEqual(Shift<std::int32_t>::masked(x), 31);
+    XCTAssertEqual(Shift<std::uint32_t>::masked(x), 31);
 
-    XCTAssertEqual(x.clamped<std::int64_t>(), 63);
-    XCTAssertEqual(x.clamped<std::uint64_t>(), 63);
+    XCTAssertEqual(Shift<std::int64_t>::masked(x), 63);
+    XCTAssertEqual(Shift<std::uint64_t>::masked(x), 63);
 }
 
 - (void)testArithmeticShiftLeftPositive {


### PR DESCRIPTION
Final part of this small refactor of the C++ code of namedstruct:
* eliminating magic constants
* renaming `uint32_t` to `Word` (makes it easier to switch everything to 64 bits, if we ever want to do so)
* stating the intent of some operations by defining appropriately named functions